### PR TITLE
Add reusable PR auto-assign workflow

### DIFF
--- a/.github/workflows/pr-auto-assign-and-notify.yml
+++ b/.github/workflows/pr-auto-assign-and-notify.yml
@@ -1,0 +1,580 @@
+name: Auto Assign PR And Notify Slack
+
+on:
+  workflow_call:
+    inputs:
+      notify_slack:
+        description: Whether to post a Slack notification after selecting a reviewer.
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
+      SLACK_CHANNEL_ID:
+        required: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign-and-notify:
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Select reviewer routing
+        id: reviewer-selection
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_REVIEWER_CONFIG_JSON: ${{ vars.PR_REVIEWER_CONFIG_JSON }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: |
+            const parseReviewerConfig = (rawConfig) => {
+              if (!rawConfig) {
+                throw new Error('Missing repository variable PR_REVIEWER_CONFIG_JSON.');
+              }
+
+              let parsedConfig;
+              try {
+                parsedConfig = JSON.parse(rawConfig);
+              } catch (error) {
+                throw new Error(`Reviewer config JSON is not valid JSON: ${error.message}`);
+              }
+
+              if (!parsedConfig || typeof parsedConfig !== 'object' || Array.isArray(parsedConfig)) {
+                throw new Error('Reviewer config must be a JSON object keyed by GitHub username.');
+              }
+
+              return parsedConfig;
+            };
+
+            const hasSlackUserId = (value) =>
+              value &&
+              typeof value === 'object' &&
+              typeof value.slack === 'string' &&
+              value.slack.trim().length > 0;
+
+            const getConfiguredReviewerPool = (reviewerConfig, prAuthorLogin) =>
+              Object.entries(reviewerConfig)
+                .filter(([username, value]) => username !== prAuthorLogin && hasSlackUserId(value))
+                .map(([username]) => username);
+
+            const selectReviewer = (eligiblePool, reviewerSelectionScores, random = Math.random) => {
+              if (!Array.isArray(eligiblePool) || eligiblePool.length === 0) {
+                return null;
+              }
+
+              const lowestTodayAssignmentCount = Math.min(
+                ...eligiblePool.map((reviewer) => reviewerSelectionScores[reviewer].todayAssignments),
+              );
+              const lowestTodayAssignmentPool = eligiblePool.filter(
+                (reviewer) =>
+                  reviewerSelectionScores[reviewer].todayAssignments === lowestTodayAssignmentCount,
+              );
+              const lowestActiveAssignmentCount = Math.min(
+                ...lowestTodayAssignmentPool.map(
+                  (reviewer) => reviewerSelectionScores[reviewer].activeAssignments,
+                ),
+              );
+              const lowestLoadPool = lowestTodayAssignmentPool.filter(
+                (reviewer) =>
+                  reviewerSelectionScores[reviewer].activeAssignments === lowestActiveAssignmentCount,
+              );
+
+              return lowestLoadPool[Math.floor(random() * lowestLoadPool.length)];
+            };
+
+            const UNAVAILABLE_STATUS_PATTERN =
+              /\b(ooo|ooto|out of office|pto|vacation|holiday|sick|out sick|medical|offline|unavailable|away|focus|heads down|do not disturb|dnd|parental|leave|personal time)\b|:palm_tree:|🌴/iu;
+
+            const isActiveSlackStatus = (profile) => {
+              if (!profile || typeof profile !== 'object') {
+                return false;
+              }
+
+              const statusText = typeof profile.status_text === 'string' ? profile.status_text.trim() : '';
+              const statusEmoji = typeof profile.status_emoji === 'string' ? profile.status_emoji.trim() : '';
+              const statusExpiration =
+                typeof profile.status_expiration === 'number' ? profile.status_expiration : 0;
+
+              if (!statusText && !statusEmoji) {
+                return false;
+              }
+
+              return statusExpiration === 0 || statusExpiration > Math.floor(Date.now() / 1000);
+            };
+
+            const isUnavailableSlackStatus = (profile) => {
+              if (!isActiveSlackStatus(profile)) {
+                return false;
+              }
+
+              const statusText = typeof profile.status_text === 'string' ? profile.status_text : '';
+              const statusEmoji = typeof profile.status_emoji === 'string' ? profile.status_emoji : '';
+              const statusValue = `${statusText} ${statusEmoji}`;
+
+              return UNAVAILABLE_STATUS_PATTERN.test(statusValue);
+            };
+
+            const pr = context.payload.pull_request;
+            const prAuthorLogin = pr.user.login;
+            const currentHeadSha = pr.head.sha;
+            const requestedHumanReviewers = (pr.requested_reviewers ?? []).filter(
+              (reviewer) => reviewer?.type !== 'Bot',
+            );
+            const requestedReviewerLogins = requestedHumanReviewers.map((reviewer) => reviewer.login);
+            const hasRequestedTeam = (pr.requested_teams ?? []).length > 0;
+            const action = context.payload.action;
+            const isReadyForReviewEvent = context.payload.action === 'ready_for_review';
+            const shouldCheckExistingApprovals = ['ready_for_review', 'reopened'].includes(action);
+
+            const setSelectionOutputs = ({
+              reviewers,
+              shouldRequestReviewer,
+              shouldNotify,
+            }) => {
+              core.setOutput('reviewers', JSON.stringify(reviewers));
+              core.setOutput('should_request_reviewer', shouldRequestReviewer ? 'true' : 'false');
+              core.setOutput('should_notify', shouldNotify ? 'true' : 'false');
+            };
+
+            const getSlackProfile = async (slackUserId) => {
+              const response = await fetch(
+                `https://slack.com/api/users.profile.get?user=${encodeURIComponent(slackUserId)}`,
+                {
+                  headers: {
+                    Authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                  },
+                },
+              );
+
+              if (!response.ok) {
+                throw new Error(`Slack users.profile.get returned HTTP ${response.status}`);
+              }
+
+              const body = await response.json();
+              if (!body.ok) {
+                const error = new Error(
+                  `Slack users.profile.get failed: ${body.error ?? 'unknown_error'}`,
+                );
+                error.slackError = body.error;
+                throw error;
+              }
+
+              return body.profile;
+            };
+
+            const isFatalSlackLookupError = (error) =>
+              ['invalid_auth', 'missing_scope', 'not_authed', 'token_revoked', 'account_inactive'].includes(
+                error.slackError,
+              );
+
+            const filterUnavailableReviewers = async (reviewerConfig, reviewers) => {
+              if (!process.env.SLACK_BOT_TOKEN) {
+                core.setFailed('Missing repository secret SLACK_BOT_TOKEN.');
+                return null;
+              }
+
+              let availabilityChecks;
+              try {
+                availabilityChecks = await Promise.all(
+                  reviewers.map(async (reviewer) => {
+                    const slackUserId = reviewerConfig[reviewer].slack.trim();
+
+                    try {
+                      const profile = await getSlackProfile(slackUserId);
+                      if (isUnavailableSlackStatus(profile)) {
+                        const statusText = profile.status_text ? ` "${profile.status_text}"` : '';
+                        const statusEmoji = profile.status_emoji ? ` ${profile.status_emoji}` : '';
+                        core.info(`Skipping ${reviewer}; Slack status is set to${statusText}${statusEmoji}.`);
+                        return null;
+                      }
+                    } catch (error) {
+                      if (isFatalSlackLookupError(error)) {
+                        throw error;
+                      }
+
+                      core.warning(
+                        `Could not read Slack status for ${reviewer}; keeping them eligible: ${error.message}`,
+                      );
+                    }
+
+                    return reviewer;
+                  }),
+                );
+              } catch (error) {
+                core.setFailed(`Slack status lookup cannot continue: ${error.message}`);
+                return null;
+              }
+
+              return availabilityChecks.filter(Boolean);
+            };
+
+            const getReviewerSelectionScores = async (reviewers) => {
+              const reviewerSet = new Set(reviewers);
+              const startOfToday = new Date();
+              startOfToday.setHours(0, 0, 0, 0);
+              const startOfTodayTimestamp = startOfToday.getTime();
+              const scores = Object.fromEntries(
+                reviewers.map((reviewer) => [
+                  reviewer,
+                  {
+                    todayAssignments: 0,
+                    activeAssignments: 0,
+                  },
+                ]),
+              );
+              const getCreditedReviewers = (pullRequest) => {
+                const creditedReviewers = new Set();
+                for (const reviewer of pullRequest.requested_reviewers ?? []) {
+                  if (reviewer?.type !== 'Bot' && reviewerSet.has(reviewer.login)) {
+                    creditedReviewers.add(reviewer.login);
+                  }
+                }
+                return creditedReviewers;
+              };
+              const getTodayHumanReviewers = async (pullNumber) => {
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                  per_page: 100,
+                });
+                const creditedReviewers = new Set();
+
+                for (const review of reviews) {
+                  if (
+                    review.user?.type === 'Bot' ||
+                    typeof review.user?.login !== 'string' ||
+                    !reviewerSet.has(review.user.login) ||
+                    review.state === 'DISMISSED'
+                  ) {
+                    continue;
+                  }
+
+                  const submittedAtTimestamp = new Date(review.submitted_at).getTime();
+                  if (submittedAtTimestamp < startOfTodayTimestamp) {
+                    continue;
+                  }
+
+                  creditedReviewers.add(review.user.login);
+                }
+
+                return creditedReviewers;
+              };
+
+              for await (const response of github.paginate.iterator(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'all',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 100,
+              })) {
+                let reachedPullRequestsUpdatedBeforeToday = false;
+
+                for (const recentPullRequest of response.data) {
+                  if (recentPullRequest.number === pr.number) {
+                    continue;
+                  }
+
+                  const updatedAtTimestamp = new Date(recentPullRequest.updated_at).getTime();
+                  if (updatedAtTimestamp < startOfTodayTimestamp) {
+                    reachedPullRequestsUpdatedBeforeToday = true;
+                    break;
+                  }
+
+                  const creditedReviewers = await getTodayHumanReviewers(recentPullRequest.number);
+                  if (creditedReviewers.size === 0) {
+                    for (const reviewer of getCreditedReviewers(recentPullRequest)) {
+                      creditedReviewers.add(reviewer);
+                    }
+                  }
+
+                  if (creditedReviewers.size === 0) {
+                    continue;
+                  }
+
+                  for (const reviewer of creditedReviewers) {
+                    scores[reviewer].todayAssignments += 1;
+                  }
+                }
+
+                if (reachedPullRequestsUpdatedBeforeToday) {
+                  break;
+                }
+              }
+
+              for await (const response of github.paginate.iterator(github.rest.pulls.list, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                sort: 'updated',
+                direction: 'desc',
+                per_page: 100,
+              })) {
+                for (const openPullRequest of response.data) {
+                  if (openPullRequest.number === pr.number) {
+                    continue;
+                  }
+
+                  const creditedReviewers = getCreditedReviewers(openPullRequest);
+                  if (creditedReviewers.size === 0) {
+                    continue;
+                  }
+
+                  for (const reviewer of creditedReviewers) {
+                    scores[reviewer].activeAssignments += 1;
+                  }
+                }
+              }
+
+              return scores;
+            };
+
+            const getApprovedReviewersForCurrentHead = async () => {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+              const latestReviewByAuthor = new Map();
+
+              for (const review of reviews) {
+                if (
+                  review.user?.type === 'Bot' ||
+                  typeof review.user?.login !== 'string' ||
+                  review.commit_id !== currentHeadSha
+                ) {
+                  continue;
+                }
+
+                latestReviewByAuthor.set(review.user.login, review.state);
+              }
+
+              return [...latestReviewByAuthor.entries()]
+                .filter(([, state]) => state === 'APPROVED')
+                .map(([login]) => login);
+            };
+
+            if (requestedHumanReviewers.length > 0 || hasRequestedTeam) {
+              core.info(
+                'PR already has a human reviewer or review team requested. Using the current reviewer assignment state.',
+              );
+              setSelectionOutputs({
+                reviewers: requestedReviewerLogins,
+                shouldRequestReviewer: false,
+                shouldNotify: isReadyForReviewEvent && requestedReviewerLogins.length > 0,
+              });
+              return;
+            }
+
+            if (shouldCheckExistingApprovals) {
+              const approvedReviewerLogins = await getApprovedReviewersForCurrentHead();
+              if (approvedReviewerLogins.length > 0) {
+                core.info(
+                  `PR already has human approval on the current head commit from: ${approvedReviewerLogins.join(', ')}.`,
+                );
+                setSelectionOutputs({
+                  reviewers: approvedReviewerLogins,
+                  shouldRequestReviewer: false,
+                  shouldNotify: false,
+                });
+                return;
+              }
+            }
+
+            let reviewerConfig;
+            try {
+              reviewerConfig = parseReviewerConfig(process.env.PR_REVIEWER_CONFIG_JSON);
+            } catch (error) {
+              core.setFailed(error.message);
+              return;
+            }
+
+            const configuredPool = getConfiguredReviewerPool(reviewerConfig, prAuthorLogin);
+
+            if (configuredPool.length === 0) {
+              core.setFailed(
+                'No eligible reviewers with Slack IDs remain after excluding the PR author.',
+              );
+              return;
+            }
+
+            const eligiblePool = await filterUnavailableReviewers(reviewerConfig, configuredPool);
+            if (!eligiblePool) {
+              return;
+            }
+
+            if (eligiblePool.length === 0) {
+              core.setFailed(
+                'No eligible reviewers remain after excluding the PR author and unavailable Slack statuses.',
+              );
+              return;
+            }
+
+            const reviewerSelectionScores = await getReviewerSelectionScores(eligiblePool);
+            const reviewer = selectReviewer(eligiblePool, reviewerSelectionScores);
+            core.info(`Reviewer selection scores: ${JSON.stringify(reviewerSelectionScores)}`);
+            core.info(`Selected reviewer: ${reviewer}`);
+            setSelectionOutputs({
+              reviewers: [reviewer],
+              shouldRequestReviewer: true,
+              shouldNotify: true,
+            });
+
+      - name: Request selected reviewer
+        if: ${{ steps.reviewer-selection.outputs.should_request_reviewer == 'true' }}
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          REVIEWERS: ${{ steps.reviewer-selection.outputs.reviewers }}
+        with:
+          script: |
+            let reviewers;
+            try {
+              reviewers = JSON.parse(process.env.REVIEWERS || '[]');
+            } catch (error) {
+              core.setFailed(`Reviewer list is not valid JSON: ${error.message}`);
+              return;
+            }
+
+            if (!Array.isArray(reviewers) || reviewers.length === 0) {
+              core.setFailed('Reviewer list must be a non-empty JSON array.');
+              return;
+            }
+
+            await github.rest.pulls.requestReviewers({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              reviewers,
+            });
+
+      - name: Resolve Slack recipients
+        if: ${{ steps.reviewer-selection.outputs.should_notify == 'true' && inputs.notify_slack }}
+        id: slack-recipient
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          REVIEWERS: ${{ steps.reviewer-selection.outputs.reviewers }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_REVIEWER_CONFIG_JSON: ${{ vars.PR_REVIEWER_CONFIG_JSON }}
+        with:
+          script: |
+            const parseReviewerConfig = (rawConfig) => {
+              if (!rawConfig) {
+                throw new Error('Missing repository variable PR_REVIEWER_CONFIG_JSON.');
+              }
+
+              let parsedConfig;
+              try {
+                parsedConfig = JSON.parse(rawConfig);
+              } catch (error) {
+                throw new Error(`Reviewer config JSON is not valid JSON: ${error.message}`);
+              }
+
+              if (!parsedConfig || typeof parsedConfig !== 'object' || Array.isArray(parsedConfig)) {
+                throw new Error('Reviewer config must be a JSON object keyed by GitHub username.');
+              }
+
+              return parsedConfig;
+            };
+
+            const resolveSlackMentions = (reviewers, reviewerConfig) =>
+              reviewers.flatMap((reviewer) => {
+                const slackUserId = reviewerConfig?.[reviewer]?.slack;
+                if (typeof slackUserId !== 'string') {
+                  return [];
+                }
+
+                const trimmedSlackUserId = slackUserId.trim();
+                if (trimmedSlackUserId.length === 0) {
+                  return [];
+                }
+
+                return [`<@${trimmedSlackUserId}>`];
+              });
+
+            const rawReviewers = process.env.REVIEWERS;
+            const author = process.env.AUTHOR;
+
+            let reviewers;
+            try {
+              reviewers = JSON.parse(rawReviewers || '[]');
+            } catch (error) {
+              core.setFailed(`Reviewer list is not valid JSON: ${error.message}`);
+              return;
+            }
+
+            if (!Array.isArray(reviewers)) {
+              core.setFailed('Reviewer list must be a JSON array.');
+              return;
+            }
+
+            let reviewerConfig;
+            try {
+              reviewerConfig = parseReviewerConfig(process.env.PR_REVIEWER_CONFIG_JSON);
+            } catch (error) {
+              core.setFailed(error.message);
+              return;
+            }
+
+            const slackMentions = resolveSlackMentions(reviewers, reviewerConfig);
+            for (const reviewer of reviewers) {
+              if (!reviewerConfig?.[reviewer]?.slack) {
+                core.warning(`No Slack user ID configured for GitHub user "${reviewer}". Skipping Slack mention.`);
+              }
+            }
+
+            if (slackMentions.length === 0) {
+              core.info('No Slack mentions could be resolved for the selected reviewers.');
+              core.setOutput('should_post', 'false');
+              return;
+            }
+
+            const authorSlackUserId = reviewerConfig?.[author]?.slack;
+            if (!authorSlackUserId) {
+              core.warning(`No Slack user ID configured for PR author "${author}". Falling back to GitHub username.`);
+            }
+
+            const assignmentSummary = `Assigned to: ${slackMentions.join(' ')}`;
+
+            core.setOutput('should_post', 'true');
+            core.setOutput('assignment_summary', assignmentSummary);
+            core.setOutput('reviewer_mentions', slackMentions.join(' '));
+            core.setOutput('author_reference', authorSlackUserId ? `<@${authorSlackUserId}>` : `\`${author}\``);
+
+      - name: Post Slack notification
+        if: ${{ steps.reviewer-selection.outputs.should_notify == 'true' && inputs.notify_slack && steps.slack-recipient.outputs.should_post == 'true' }}
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "${{ steps.slack-recipient.outputs.assignment_summary }} | PR #${{ github.event.pull_request.number }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*PR review requested*"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Assigned to:* ${{ steps.slack-recipient.outputs.reviewer_mentions }}"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*Pull request:* <${{ github.event.pull_request.html_url }}|PR #${{ github.event.pull_request.number }}>"
+              - type: section
+                text:
+                  type: plain_text
+                  text: "${{ github.event.pull_request.title }}"
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "Requested by ${{ steps.slack-recipient.outputs.author_reference }}"

--- a/.github/workflows/pr-auto-assign-and-notify.yml
+++ b/.github/workflows/pr-auto-assign-and-notify.yml
@@ -10,18 +10,17 @@ on:
         default: true
     secrets:
       SLACK_BOT_TOKEN:
-        required: false
+        required: true
       SLACK_CHANNEL_ID:
-        required: false
+        required: true
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:
   assign-and-notify:
-    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.fork == false }}
+    if: ${{ github.event.pull_request && !github.event.pull_request.draft && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
 
     steps:
@@ -174,11 +173,6 @@ jobs:
               );
 
             const filterUnavailableReviewers = async (reviewerConfig, reviewers) => {
-              if (!process.env.SLACK_BOT_TOKEN) {
-                core.setFailed('Missing repository secret SLACK_BOT_TOKEN.');
-                return null;
-              }
-
               let availabilityChecks;
               try {
                 availabilityChecks = await Promise.all(
@@ -526,7 +520,7 @@ jobs:
             const slackMentions = resolveSlackMentions(reviewers, reviewerConfig);
             for (const reviewer of reviewers) {
               if (!reviewerConfig?.[reviewer]?.slack) {
-                core.warning(`No Slack user ID configured for GitHub user "${reviewer}". Skipping Slack mention.`);
+                core.warning(`No Slack user ID configured for GitHub user \"${reviewer}\". Skipping Slack mention.`);
               }
             }
 
@@ -538,7 +532,7 @@ jobs:
 
             const authorSlackUserId = reviewerConfig?.[author]?.slack;
             if (!authorSlackUserId) {
-              core.warning(`No Slack user ID configured for PR author "${author}". Falling back to GitHub username.`);
+              core.warning(`No Slack user ID configured for PR author \"${author}\". Falling back to GitHub username.`);
             }
 
             const assignmentSummary = `Assigned to: ${slackMentions.join(' ')}`;
@@ -555,26 +549,46 @@ jobs:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ secrets.SLACK_CHANNEL_ID }}
-            text: "${{ steps.slack-recipient.outputs.assignment_summary }} | PR #${{ github.event.pull_request.number }}"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "*PR review requested*"
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "*Assigned to:* ${{ steps.slack-recipient.outputs.reviewer_mentions }}"
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: "*Pull request:* <${{ github.event.pull_request.html_url }}|PR #${{ github.event.pull_request.number }}>"
-              - type: section
-                text:
-                  type: plain_text
-                  text: "${{ github.event.pull_request.title }}"
-              - type: context
-                elements:
-                  - type: mrkdwn
-                    text: "Requested by ${{ steps.slack-recipient.outputs.author_reference }}"
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL_ID }}",
+              "text": ${{ toJson(format('{0} | PR #{1}', steps.slack-recipient.outputs.assignment_summary, github.event.pull_request.number)) }},
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*PR review requested*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJson(format('*Assigned to:* {0}', steps.slack-recipient.outputs.reviewer_mentions)) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJson(format('*Pull request:* <{0}|PR #{1}>', github.event.pull_request.html_url, github.event.pull_request.number)) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ${{ toJson(github.event.pull_request.title) }}
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ${{ toJson(format('Requested by {0}', steps.slack-recipient.outputs.author_reference)) }}
+                    }
+                  ]
+                }
+              ]
+            }

--- a/workflow-templates/pr-auto-assign-and-notify.properties.json
+++ b/workflow-templates/pr-auto-assign-and-notify.properties.json
@@ -1,0 +1,9 @@
+{
+  "name": "PR auto assign and notify",
+  "description": "Request a reviewer and notify Slack when a pull request is ready.",
+  "iconName": "octicon git-pull-request",
+  "categories": [
+    "Automation",
+    "Code review"
+  ]
+}

--- a/workflow-templates/pr-auto-assign-and-notify.yml
+++ b/workflow-templates/pr-auto-assign-and-notify.yml
@@ -9,10 +9,11 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 jobs:
   pr-auto-assign-and-notify:
     uses: Swell-Platform/.github/.github/workflows/pr-auto-assign-and-notify.yml@main
-    secrets: inherit
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/workflow-templates/pr-auto-assign-and-notify.yml
+++ b/workflow-templates/pr-auto-assign-and-notify.yml
@@ -1,0 +1,18 @@
+name: PR auto assign and notify
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  pr-auto-assign-and-notify:
+    uses: Swell-Platform/.github/.github/workflows/pr-auto-assign-and-notify.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a reusable `pr-auto-assign-and-notify` workflow in `Swell-Platform/.github`
- inline the reviewer-routing helpers so consuming repos do not need local `.github/scripts` copies
- add an org workflow template that wraps the reusable workflow for any repo in the org

## How to use
1. In a consuming repo, add the workflow template or create a wrapper workflow.
2. Ensure the repo has `PR_REVIEWER_CONFIG_JSON`, `SLACK_BOT_TOKEN`, and `SLACK_CHANNEL_ID` configured.
3. Trigger on `pull_request_target` for `opened`, `reopened`, and `ready_for_review`.

## Notes
- This keeps the shared workflow self-contained instead of depending on repo-local helper scripts.
- I did not migrate existing repos in this PR; this only makes org-wide reuse available.
